### PR TITLE
Better handling of git commit hash when ngs-filters is running inside a container

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ This script wraps `fpfilter.pl` from [variant-filter](https://github.com/ckandot
 ./run-fpfilter.py -v input.vcf -b tumor.bam -g genome -f path/to/fpfilter.pl
 ```
 
-## Install Dependencies
+## How to Install Dependencies
 
 Required R Packages:
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ This script wraps `fpfilter.pl` from [variant-filter](https://github.com/ckandot
 Required R Packages:
 
 ```bash
-$ ./Rscript install-packages.R
+$ Rscript install-packages.R
 ```
 
 Required Python Libraries

--- a/applyFilter.sh
+++ b/applyFilter.sh
@@ -1,7 +1,23 @@
 #!/bin/bash
 
 SDIR="$( cd "$( dirname "$0" )" && pwd )"
-SVERSION=$(git --git-dir=$SDIR/.git --work-tree=$SDIR describe --always --long)
+
+if [ -x "$(command -v git)" ] && [ -r "$SDIR/.git" ]
+then
+    # if both Git CLI and .git exist, then use "git describe" to create version tag
+    SVERSION=$(git --git-dir=$SDIR/.git --work-tree=$SDIR describe --always --long)
+else
+    if [ -r ".git-commit-hash" ]
+    then
+        # if .git-commit-hash exists, then use the git commit hash stored in .git-commit-hash
+        SVERSION=$(cat .git-commit-hash)
+    else
+        # there is no way to figure out git commit hash
+        SVERSION="unknown"
+    fi
+fi
+
+# construct version tag
 VTAG="$(basename $SDIR)/$(basename $0) VERSION=$SVERSION"
 
 usage() {


### PR DESCRIPTION
## Issue

As far as the ngs-filters container (Docker or Singularity) is concerned, ngs-filters is not installed via `git clone`, but rather through one of the official release tags (e.g. https://github.com/mskcc/ngs-filters/releases/tag/v1.1.3). Therefore, the `.git` file won't be found in the installation directory, and we don't install Git CLI either inside the container.

Because of this, the code that tries to retrieve the latest Git commit hash (https://github.com/mskcc/ngs-filters/blob/v1.1.3/applyFilter.sh#L4) throws an error at runtime, and MAF won't have the version tag either.

```
/usr/bin/ngs-filters/applyFilter.sh: line 4: git: command not found
fatal: Not a git repository: '/usr/bin/ngs-filters/.git'
```

The workaround provided in this PR handles the following three cases:

## ngs-filters is ran from a git cloned directory

This is the case where both Git CLI and the `.git` file exists. The generated version tag would be something like this:

```
VERSION=v1.1.1-70-g0a03319
```

## containerized ngs-filters is ran

During the container build process, a new file called `.git-commit-hash` will be added to the container, and this file contains the Git commit hash that corresponds to the installed ngs-filters version. `applyFilter.sh` will use this `.git-commit-hash` file if Git CLI is not found or the `.git` file is not found.

The generated version tag would be something like this:

```
VERSION=0a033196ee92e75f94a8dd27c97d6b882210103e
```

## when nothing is found (highly unlikely)

The generated version tag would be something like this:

```
VERSION=unknown
```
